### PR TITLE
Option for trigger event, defaults to blur

### DIFF
--- a/src/showErrors.coffee
+++ b/src/showErrors.coffee
@@ -2,7 +2,13 @@ showErrorsModule = angular.module('ui.bootstrap.showErrors', [])
 
 showErrorsModule.directive 'showErrors',
 ['$timeout', 'showErrorsConfig', ($timeout, showErrorsConfig) ->
-
+    
+    getTrigger = (options) ->
+      trigger = showErrorsConfig.trigger
+      if options && options.trigger?
+        trigger = options.trigger
+      trigger
+    
     getShowSuccess = (options) ->
       showSuccess = showErrorsConfig.showSuccess
       if options && options.showSuccess?
@@ -13,6 +19,7 @@ showErrorsModule.directive 'showErrors',
       blurred = false
       options = scope.$eval attrs.showErrors
       showSuccess = getShowSuccess options
+      trigger = getTrigger options
 
       inputEl   = el[0].querySelector("[name]")
       inputNgEl = angular.element(inputEl)
@@ -20,7 +27,7 @@ showErrorsModule.directive 'showErrors',
       unless inputName
         throw "show-errors element has no child input elements with a 'name' attribute"
 
-      inputNgEl.bind 'blur', ->
+      inputNgEl.bind trigger, ->
         blurred = true
         toggleClasses formCtrl[inputName].$invalid
 
@@ -58,11 +65,16 @@ showErrorsModule.directive 'showErrors',
 
 showErrorsModule.provider 'showErrorsConfig', ->
   _showSuccess = false
+  _trigger = 'blur'
 
   @showSuccess = (showSuccess) ->
     _showSuccess = showSuccess
+    
+  @trigger = (trigger) ->
+    _trigger = trigger
 
   @$get = ->
     showSuccess: _showSuccess
+    trigger: _trigger
 
   return


### PR DESCRIPTION
Hello Paul,

Really useful directive. I've been using it for a bit, but I figured I should share this tiny modification to make blur configurable. For some fields where I have very specific patterns it is ideal not to wait for a blur event.

``` html
<form name="userForm">
  <div class="form-group" show-errors="{ trigger: 'keypress' }">
    <input type="text" name="firstName" ng-model="firstName" ng-pattern="/^foo$/" ng-required />
  </div>
</form>
```

Thanks for the great directive!

(I edited the coffee script in github really quick, so hopefully there are no typos)
